### PR TITLE
only diff files whose string *ends* with package-lock.json

### DIFF
--- a/bin/diff-lockfiles.js
+++ b/bin/diff-lockfiles.js
@@ -9,7 +9,7 @@ const execPromise = promisify(exec);
 const version = '1.0.2';
 
 async function lockFiles(a, b) {
-    const output = await execPromise(`git diff ${a} ${b} --name-only | grep package-lock.json`);
+    const output = await execPromise(`git diff ${a} ${b} --name-only | grep 'package-lock.json$'`);
     const lines = output.stdout;
     const list = lines.trim().split(/\r\n|\r|\n/);
 


### PR DESCRIPTION
For complicated reasons, I happen to track a `package-lock.json.patch` file in my repository, which is a diff from my local `package-lock.json` with respect to an upstream repo. (For complicated reasons, we are not simply a git fork of the upstream repo but rather include it as a submodule.)

It'd be nice to not have this tool try to diff that file (which is not valid JSON, but rather is a patch file).

Nice tool btw! 🙂 Super handy!