### PR TITLE
Added --shallow to only handle direct dependencies

### DIFF
--- a/bin/diff-lockfiles.js
+++ b/bin/diff-lockfiles.js
@@ -36,13 +36,14 @@ cli
     .option('-f, --format <format>', 'changes the output format (table|json|text)', 'table')
     .option('-m, --max-buffer', 'maximum read buffer size', 1024 * 10000)
     .option('-c, --color', 'colorizes certain output formats', false)
+    .option('-s, --shallow', 'only include direct dependencies of the project', false)
     .action((from, to, options) => {
         lockFiles(from, to).then((v) => {
             for (let filename of v) {
                 const a = lockFileString(options.maxBuffer, from, filename).then((s) => { return JSON.parse(s); });
                 const b = lockFileString(options.maxBuffer, to, filename).then((s) => { return JSON.parse(s); });
                 Promise.all([a, b]).then((values) => {
-                    const changes = diff(values[0], values[1]);
+                    const changes = diff(values[0], values[1], options.shallow);
                     print(changes, {
                         color: options.color,
                         format: options.format,

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,14 +3,27 @@ import chalk from 'chalk';
 import semver from 'semver';
 import { table } from 'table';
 
-export function diff(oldLock, newLock) {
+export function diff(oldLock, newLock, shallow) {
   const changes = {};
+  
+  function filterPackages(packages) {
+    let entries = Object.entries(packages);
+    if (shallow) {
+      const selfPackage = packages[''];
+      const directDeps = new Set(
+          ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']
+              .flatMap(key => Object.keys(selfPackage[key] ?? {}))
+              .map(pkg => `node_modules/${pkg}`));
+      entries = entries.filter(([name]) => directDeps.has(name) || name === ''); // include self for compatibility
+    }
+    return entries;
+  }
 
-  Object.entries(oldLock.packages).forEach(([name, { version }]) => {
+  filterPackages(oldLock.packages).forEach(([name, { version }]) => {
     changes[name] = [version, null];
   });
 
-  Object.entries(newLock.packages).forEach(([name, { version }]) => {
+  filterPackages(newLock.packages).forEach(([name, { version }]) => {
     if (changes[name] && changes[name][0]) {
       if (semver.eq(changes[name][0], version)) {
         delete changes[name];


### PR DESCRIPTION
We have a use case where we only want to report changes in the root level dependencies of our project, so here's a new cli flag (-s or --shallow) which filters out packages that are not directly listed as dependencies in the project itself. The default value is false to maintain backwards compatibility.

In case a package has changed from an explicit dependency to implicit (or vice versa), the output will show removed or added rather than the actual version, which may or may not be misleading, but it's correct in our case.