### PR TITLE
Explain to use global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,17 @@ operates on Git commit ranges rather than on files.
 
 ## Example
 
+Install `diff-lockfiles` globally:
+
 ```sh
-npm install diff-lockfiles
-diff-lockfiles --color origin/main dependabot/branch
+npm install -g diff-lockfiles
 ```
 
+Try it out:
+
 ```ssh
+diff-lockfiles --color origin/main dependabot/branch
+
 diff-lockfiles --color HEAD~1 HEAD
 ```
 


### PR DESCRIPTION
You might want to use the `-g` flag to install your script globally. So it will not be part of a project and it can be used across multiple projects as well.

Which makes a lot of sense in this case.