### PR TITLE
Normalize package repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "a diff for package-lock.json files",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/oalders/diff-lockfiles.git"
+    "url": "git+https://github.com/oalders/diff-lockfiles.git"
   },
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- update `package.json` repository metadata from an SSH GitHub URL to a public `git+https` URL
- leave runtime code, dependencies, package version, and package contents unchanged

## Validation
- metadata assertion for `package.json` repository URL
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`